### PR TITLE
SSL limitations prevents the examples to run right away.

### DIFF
--- a/source/Simplest OAuth2 Walkthrough/Apis/Startup.cs
+++ b/source/Simplest OAuth2 Walkthrough/Apis/Startup.cs
@@ -11,6 +11,12 @@ namespace Apis
     {
         public void Configuration(IAppBuilder app)
         {
+            // Disable SSL Validation
+            // Credits: http://stackoverflow.com/questions/777607/the-remote-certificate-is-invalid-according-to-the-validation-procedure-using
+            ServicePointManager.ServerCertificateValidationCallback =
+                delegate(object s, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+                { return true; };
+
             // accept access tokens from identityserver and require a scope of 'api1'
             app.UseIdentityServerBearerTokenAuthentication(new IdentityServerBearerTokenAuthenticationOptions
                 {

--- a/source/Simplest OAuth2 Walkthrough/Client/Program.cs
+++ b/source/Simplest OAuth2 Walkthrough/Client/Program.cs
@@ -8,6 +8,12 @@ namespace Client
     {
         static void Main(string[] args)
         {
+            // Disable SSL Validation for testing purposes
+            // Credits: http://stackoverflow.com/questions/777607/the-remote-certificate-is-invalid-according-to-the-validation-procedure-using
+            ServicePointManager.ServerCertificateValidationCallback =
+                delegate(object s, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+                { return true; };
+            
             var response = GetClientToken();
             CallApi(response);
 

--- a/source/Simplest OAuth2 Walkthrough/IdSrv/Program.cs
+++ b/source/Simplest OAuth2 Walkthrough/IdSrv/Program.cs
@@ -10,6 +10,7 @@ namespace IdSrv
         {
             LogProvider.SetCurrentLogProvider(new DiagnosticsTraceLogProvider());
 
+            // The port here must be one between 44300 and 44399 (or just 443), or else no request will be processed.
             using (WebApp.Start<Startup>("https://localhost:44333"))
             {
                 Console.WriteLine("server running...");


### PR DESCRIPTION
Hello, I had bad times making this run because of SSL validations. I think with these changes the community will be relieved from the burden of setting SSL Certs until they have a mature code.

I hope this suggestion is appreciated.